### PR TITLE
feat: add light mode support

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -2,6 +2,9 @@ import { defineConfig } from "vocs";
 
 export default defineConfig({
   basePath: process.env.BASE_PATH || undefined,
+  theme: {
+    colorScheme: "system",
+  },
   title: "Mirage Blog",
   logoUrl: "/logo.svg",
   iconUrl: "/logo.svg",


### PR DESCRIPTION
## Summary
- Adds `theme.colorScheme: "system"` to vocs config
- Blog now respects the user's OS light/dark preference
- Users can also toggle manually via the Vocs theme switcher

## Test plan
- [ ] Verify light mode renders correctly with OS set to light theme
- [ ] Verify dark mode still works with OS set to dark theme
- [ ] Verify manual toggle works in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)